### PR TITLE
fix(ap-bridge): harden watchdog verdict paths (#19)

### DIFF
--- a/debian/cockpit-networkmanager-halos.ap-bridge-watchdog.service
+++ b/debian/cockpit-networkmanager-halos.ap-bridge-watchdog.service
@@ -9,8 +9,15 @@ Wants=NetworkManager.service
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/halos/ap-bridge-watchdog.sh boot
-# Generous so a revert (which brings interfaces down/up) is never killed mid-way.
-TimeoutStartSec=300
+# Worst case: a boot run queues behind a concurrent switch/revert holding the
+# lock (FLOCK_WAIT=150s), then runs the full boot settle + verdict + revert +
+# terminal-fallback (NM restart) chain (~390s). 540s covers the true ceiling
+# with margin so a revert is never killed mid-way.
+TimeoutStartSec=540
+# On a non-clean exit (timeout / SIGKILL mid-revert) persist a stranded marker
+# to /var/lib (the /run verdict breadcrumb is tmpfs and isn't written when the
+# process is killed). The hook keys on $SERVICE_RESULT, so a clean run is a no-op.
+ExecStopPost=/usr/libexec/halos/ap-bridge-watchdog.sh mark-exit
 
 [Install]
 WantedBy=multi-user.target

--- a/files/halos/ap-bridge-watchdog.sh
+++ b/files/halos/ap-bridge-watchdog.sh
@@ -28,11 +28,16 @@
 #            an enslaved AP without the dropped in-file psk). No-op when the AP
 #            is not Bridged.
 #   switch - run by the live-switch deadman armed before an Isolated->Bridged
-#            switch (Unit 6): shorter window, same verdict + revert.
+#            switch (Unit 6): shorter window, same verdict + revert. Also reverts
+#            a half-built bridge left by an apply that aborted before enslaving
+#            the AP (a partial switch), which boot deliberately does not.
 #   revert - unconditional revert to Isolated (used by switch-back and
 #            disable-while-Bridged). Restores the psk into the keyfile and clears
 #            the stash. With NO_AP_UP=1, leaves the AP down
 #            (disable-while-Bridged).
+#   mark-exit - ExecStopPost hook: on a non-clean service exit (timeout / kill)
+#            persist a stranded marker to $STATE_DIR (the /run breadcrumb is
+#            tmpfs). No AP discovery, no lock, no NM interaction.
 #
 # psk handling (security): the psk only ever lives in 0600-root files — the NM
 # keyfile, the stash, and a transient passwd-file during activation. NM drops the
@@ -75,6 +80,7 @@ ISOLATED_ADDR="${ISOLATED_ADDR:-10.42.0.1}"
 STATE_DIR="${STATE_DIR:-/var/lib/halos/ap-bridge}"
 EXPECTED_GW_FILE="${EXPECTED_GW_FILE:-$STATE_DIR/expected-gateway}"
 STASH="${STASH:-$STATE_DIR/psk}"   # 0600 root; verbatim keyfile-escaped psk while Bridged
+EXIT_MARKER="${EXIT_MARKER:-$STATE_DIR/last-exit}"  # persistent non-clean-exit marker (survives reboot)
 RUN_DIR="${RUN_DIR:-/run/halos}"
 BREADCRUMB="${BREADCRUMB:-$RUN_DIR/ap-bridge-watchdog.verdict}"
 LOCKFILE="${LOCKFILE:-$RUN_DIR/ap-bridge-watchdog.lock}"
@@ -174,6 +180,43 @@ is_ap_bridged() {
     st="$($NMCLI -t -f connection.slave-type connection show "$AP_CON" 2>/dev/null | cut -d: -f2)"
     master="$($NMCLI -t -f connection.master connection show "$AP_CON" 2>/dev/null | cut -d: -f2)"
     [ "$st" = "bridge" ] || [ -n "$master" ]
+}
+
+# Positive partial-switch discriminator: the bridge is built (br0 connected with
+# eth0 enslaved as its port) but the AP is NOT a bridge port. This is the unique
+# signature an aborted enter-Bridged leaves (eth0 was downed and enslaved before
+# the AP enslave step failed). It must NOT match a healthy completed bridge —
+# there the AP *is* a port — so callers gate this behind `! is_ap_bridged`.
+is_partial_switch() {
+    local br_state eth_con
+    # nmcli GENERAL.STATE is "<code> (<text>)"; 100 == connected. Match the code,
+    # not the text — "disconnected" contains the substring "connected".
+    br_state="$($NMCLI -t -f GENERAL.STATE device show "$BRIDGE" 2>/dev/null | cut -d: -f2)"
+    eth_con="$($NMCLI -t -g GENERAL.CONNECTION device show "$UPLINK" 2>/dev/null)"
+    [ "${br_state%% *}" = "100" ] || return 1
+    [ "$eth_con" = "$BR_ETH_CON" ]
+}
+
+# ExecStopPost hook: persist a stranded marker on a NON-CLEAN exit (systemd
+# timeout / SIGKILL mid-revert). The /run verdict breadcrumb is tmpfs (lost on
+# power-cycle) and is never written when systemd kills the process, so an
+# operator otherwise can't tell after a reboot that the last run was force-
+# terminated. Gate SOLELY on $SERVICE_RESULT: for a Type=oneshot timeout/signal,
+# $EXIT_STATUS is empty or a signal NAME (never a numeric 0), so a numeric
+# comparison would misfire on exactly the case this exists to catch.
+mark_exit() {
+    [ "${SERVICE_RESULT:-success}" = "success" ] && return 0
+    mkdir -p "$STATE_DIR" 2>/dev/null || true
+    printf 'verdict=stranded\nreason=service-%s\nexit_status=%s\ntimestamp=%s\n' \
+        "${SERVICE_RESULT:-unknown}" "${EXIT_STATUS:-}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        > "$EXIT_MARKER" 2>/dev/null || true
+    chmod 0644 "$EXIT_MARKER" 2>/dev/null || true
+    # Don't claim success blind: only log "wrote" if the marker actually landed.
+    if [ -e "$EXIT_MARKER" ]; then
+        log "non-clean exit (SERVICE_RESULT=${SERVICE_RESULT:-unknown}); wrote stranded marker"
+    else
+        log "non-clean exit (SERVICE_RESULT=${SERVICE_RESULT:-unknown}); FAILED to write stranded marker"
+    fi
 }
 
 write_breadcrumb() {
@@ -459,6 +502,24 @@ do_revert() {
 run_verdict() {
     local mode="$1" window="$2"
     if ! is_ap_bridged; then
+        # Switch mode only: an aborted enter-Bridged can strand the device in a
+        # half-built bridge (br0 up, eth0 enslaved) with the AP NOT yet a port.
+        # Revert that partial state back to a reachable Isolated AP. Boot and all
+        # other modes keep the plain skip — a legitimately non-bridged device
+        # must never be reverted (that would be a needless outage).
+        if [ "$mode" = "switch" ] && is_partial_switch; then
+            # is_ap_bridged is a single un-retried nmcli read and switch mode has
+            # no boot settle, so re-confirm after a short pause that the AP is
+            # still not a port (and the half-state persists) before acting on a
+            # possible transient false-negative.
+            sleep "$POLL_INTERVAL"
+            if ! is_ap_bridged && is_partial_switch; then
+                write_breadcrumb "reverted" "partial-switch"
+                log "partial switch detected (bridge built, AP not enslaved); reverting"
+                do_revert
+                return
+            fi
+        fi
         write_breadcrumb "skipped" "ap-not-bridged"
         log "AP is not Bridged; nothing to verify ($mode)"
         return 0
@@ -501,24 +562,40 @@ run_verdict() {
 main() {
     local mode="${1:-boot}"
 
+    # mark-exit is an ExecStopPost hook: no AP discovery, no lock, no NM — it only
+    # records systemd's exit result. Handle it before everything else.
+    if [ "$mode" = "mark-exit" ]; then
+        mark_exit
+        return
+    fi
+
     # Discover the managed AP connection by its interface (id is hostname-derived,
-    # not a fixed name). An explicit AP_CON env still overrides. Fall back to the
-    # historical default only if nothing is bound to the AP interface.
+    # not a fixed name). An explicit AP_CON env still overrides.
     if [ -z "$AP_CON" ]; then
         # At boot the AP interface may not yet be claimed by a connection: the
         # unit is ordered only After=NetworkManager.service, which gates on NM
         # *starting*, not on connection activation. Discovering too early returns
-        # empty, the fallback id is wrong, and the bridged check then FALSE-SKIPS
-        # a Bridged AP (it would never be reverted if unhealthy). Wait, bounded,
-        # for the binding. The AP rides wlan0ap independent of the uplink, so this
-        # resolves quickly for an Isolated device too.
+        # empty. Wait, bounded, for the binding. The AP rides wlan0ap independent
+        # of the uplink, so this resolves quickly for an Isolated device too.
         if [ "$mode" = "boot" ]; then
             local _deadline; _deadline=$(( $(date +%s) + BOOT_SETTLE ))
             while [ -z "$($NMCLI -t -g GENERAL.CONNECTION device show "$AP_IFACE" 2>/dev/null)" ] \
                   && [ "$(date +%s)" -lt "$_deadline" ]; do sleep 1; done
         fi
         AP_CON="$($NMCLI -t -g GENERAL.CONNECTION device show "$AP_IFACE" 2>/dev/null)"
-        [ -n "$AP_CON" ] || AP_CON="Halos-AP"
+    fi
+    # No connection is bound to the AP interface. Never synthesize a fake id (the
+    # old "Halos-AP" fallback): is_ap_bridged / keyfile derivation off a
+    # non-existent connection would FALSE-SKIP a possibly-unhealthy Bridged AP.
+    # Apply-gated modes (stash/up) FAIL so the enter-Bridged `set -e` aborts;
+    # verdict modes surface it honestly and do nothing destructive (there is
+    # nothing safe to revert when the AP can't even be identified).
+    if [ -z "$AP_CON" ]; then
+        log "AP connection not discovered on $AP_IFACE ($mode)"
+        case "$mode" in
+            stash|up) return 1 ;;
+            *) write_breadcrumb "undetermined" "ap-con-not-discovered"; return 0 ;;
+        esac
     fi
     # Discover the keyfile path (not derivable from the id); fall back to the
     # id-based path only if discovery fails.
@@ -564,7 +641,7 @@ main() {
             stash_psk
             ;;
         *)
-            echo "usage: $0 {stash|up|boot|switch|revert}" >&2
+            echo "usage: $0 {stash|up|boot|switch|revert|mark-exit}" >&2
             return 2
             ;;
     esac

--- a/run
+++ b/run
@@ -122,6 +122,17 @@ function hooks-run {
   lefthook run pre-commit
 }
 
+function test {
+  #@ Run the watchdog sourced unit tests (no NetworkManager needed)
+  #@ Category: Utility
+  if command -v shellcheck &> /dev/null; then
+    shellcheck files/halos/ap-bridge-watchdog.sh test/ap-bridge-watchdog.test.sh
+  else
+    echo "note: shellcheck not found; skipping lint"
+  fi
+  bash test/ap-bridge-watchdog.test.sh
+}
+
 function help {
   #@ Show available commands
   echo "cockpit-networkmanager-halos development commands:"
@@ -156,7 +167,7 @@ shift
 
 # Run command
 case "$COMMAND" in
-  build|bumpversion|deploy|test-cycle|docker-build|clean|hooks-install|hooks-run|help)
+  build|bumpversion|deploy|test|test-cycle|docker-build|clean|hooks-install|hooks-run|help)
     "$COMMAND" "$@"
     ;;
   *)

--- a/test/ap-bridge-watchdog.test.sh
+++ b/test/ap-bridge-watchdog.test.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Sourced unit tests for ap-bridge-watchdog.sh pure/near-pure logic. NM/IP are
+# stubbed via the script's env-overridable command vars and a dispatching nmcli
+# function, so no real NetworkManager is touched. Run: ./run test (or bash this).
+#
+# Many locals here are consumed by the sourced script, not this file.
+# shellcheck disable=SC2034
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WD="$HERE/../files/halos/ap-bridge-watchdog.sh"
+
+TD="$(mktemp -d)"; trap 'rm -rf "$TD"' EXIT
+export STATE_DIR="$TD/state" RUN_DIR="$TD/run"
+export EXIT_MARKER="$TD/state/last-exit"
+export BREADCRUMB="$TD/run/ap-bridge-watchdog.verdict"
+export LOCKFILE="$TD/run/lock"
+mkdir -p "$STATE_DIR" "$RUN_DIR"
+
+# shellcheck source=/dev/null
+source "$WD"
+
+pass=0; fail=0
+ck() { if [ "$2" = "$3" ]; then pass=$((pass+1)); else fail=$((fail+1)); printf 'FAIL: %s — expected [%s] got [%s]\n' "$1" "$2" "$3"; fi; }
+
+# Dispatching nmcli stub. Behaviour driven by STUB_* globals.
+STUB_AP_SLAVE="" STUB_AP_MASTER="" STUB_BR0_STATE="" STUB_ETH_CON="" STUB_AP_DEVCON=""
+nmcli() {
+    local a="$*"
+    case "$a" in
+        *"connection.slave-type connection show"*) printf 'connection.slave-type:%s\n' "$STUB_AP_SLAVE" ;;
+        *"connection.master connection show"*)     printf 'connection.master:%s\n' "$STUB_AP_MASTER" ;;
+        *"GENERAL.STATE device show $BRIDGE"*)      printf 'GENERAL.STATE:%s\n' "$STUB_BR0_STATE" ;;
+        *"GENERAL.CONNECTION device show $UPLINK"*) printf '%s\n' "$STUB_ETH_CON" ;;
+        *"GENERAL.CONNECTION device show $AP_IFACE"*) printf '%s\n' "$STUB_AP_DEVCON" ;;
+        *) : ;;
+    esac
+}
+POLL_INTERVAL=0   # no real sleeps in the re-confirm path
+
+# --- backfill: pure verdict logic -------------------------------------------
+lq() { lease_qualifies "$1" && echo yes || echo no; }
+ck "lease empty"    no  "$(lq '')"
+ck "lease 169.254"  no  "$(lq '169.254.1.5/16')"
+ck "lease 10.42"    no  "$(lq '10.42.0.1/24')"
+ck "lease real"     yes "$(lq '192.168.8.50/24')"
+ck "verdict healthy"   "healthy"                      "$(compute_verdict '192.168.8.50/24' 1 '192.168.8.1' '192.168.8.1')"
+ck "verdict gw-mismatch" "unhealthy:gateway-mismatch" "$(compute_verdict '192.168.8.50/24' 1 '10.0.0.1' '192.168.8.1')"
+ck "verdict no-route"  "unhealthy:no-default-route"   "$(compute_verdict '192.168.8.50/24' 0 '192.168.8.1' '')"
+
+# --- is_partial_switch: positive half-state discriminator -------------------
+ps() { is_partial_switch && echo yes || echo no; }
+STUB_BR0_STATE="100 (connected)"; STUB_ETH_CON="br0-eth0"
+ck "partial: br0 up + eth0 enslaved"        yes "$(ps)"
+STUB_BR0_STATE="30 (disconnected)"; STUB_ETH_CON="br0-eth0"
+ck "partial: br0 down -> no"                no  "$(ps)"
+STUB_BR0_STATE="100 (connected)"; STUB_ETH_CON="Wired connection 1"
+ck "partial: eth0 standalone -> no"         no  "$(ps)"
+
+# --- mark_exit: gate solely on SERVICE_RESULT -------------------------------
+rm -f "$EXIT_MARKER"
+( SERVICE_RESULT=success; mark_exit ); ck "mark_exit success -> rc0" "0" "$?"
+ck "mark_exit success -> no marker" "no" "$([ -e "$EXIT_MARKER" ] && echo yes || echo no)"
+( unset SERVICE_RESULT; mark_exit ); ck "mark_exit unset(=success) -> no marker" "no" "$([ -e "$EXIT_MARKER" ] && echo yes || echo no)"
+( SERVICE_RESULT=timeout EXIT_STATUS=; mark_exit )
+ck "mark_exit timeout -> marker written" "yes" "$([ -e "$EXIT_MARKER" ] && echo yes || echo no)"
+ck "mark_exit timeout -> verdict=stranded" "stranded" "$(sed -n 's/^verdict=//p' "$EXIT_MARKER")"
+ck "mark_exit timeout -> reason service-timeout" "service-timeout" "$(sed -n 's/^reason=//p' "$EXIT_MARKER")"
+rm -f "$EXIT_MARKER"
+
+# --- run_verdict: switch-mode half-switch revert ----------------------------
+AP_CON="Halos-X"
+do_revert() { echo "REVERTED" >> "$TD/revert.log"; }   # override the real teardown
+read_expected_gateway() { echo ""; }
+crumb_reason() { sed -n 's/^reason=//p' "$BREADCRUMB"; }
+crumb_verdict() { sed -n 's/^verdict=//p' "$BREADCRUMB"; }
+
+# not bridged + partial present + switch mode -> revert
+: > "$TD/revert.log"; : > "$BREADCRUMB"
+STUB_AP_SLAVE="" STUB_AP_MASTER="" STUB_BR0_STATE="100 (connected)" STUB_ETH_CON="br0-eth0"
+run_verdict switch 0
+ck "switch+partial -> verdict reverted"  "reverted"       "$(crumb_verdict)"
+ck "switch+partial -> reason partial"    "partial-switch" "$(crumb_reason)"
+ck "switch+partial -> do_revert ran"     "REVERTED"       "$(cat "$TD/revert.log" 2>/dev/null)"
+
+# not bridged + NOT partial (eth0 standalone) + switch -> skip, no revert
+: > "$TD/revert.log"; : > "$BREADCRUMB"
+STUB_ETH_CON="Wired connection 1"
+run_verdict switch 0
+ck "switch+not-partial -> skipped"       "skipped"        "$(crumb_verdict)"
+ck "switch+not-partial -> no revert"     ""               "$(cat "$TD/revert.log" 2>/dev/null)"
+
+# CRITICAL regression guard: boot + partial present -> skip, NEVER revert
+: > "$TD/revert.log"; : > "$BREADCRUMB"
+STUB_ETH_CON="br0-eth0"
+run_verdict boot 0
+ck "boot+partial -> skipped (no revert)" "skipped"        "$(crumb_verdict)"
+ck "boot+partial -> NO revert"           ""               "$(cat "$TD/revert.log" 2>/dev/null)"
+
+# --- main(): empty-AP_CON dispatch is mode-aware ----------------------------
+# AP_CON="" (defined-empty) mirrors the script's own `AP_CON="${AP_CON:-}"`; the
+# real invocation never leaves it unset, so don't `unset` it under set -u.
+STUB_AP_DEVCON=""   # discovery finds nothing bound to the AP iface
+: > "$BREADCRUMB"
+( AP_CON=""; BOOT_SETTLE=0; main boot >/dev/null 2>&1 ); ck "main boot + no AP_CON -> rc0" "0" "$?"
+ck "main boot + no AP_CON -> undetermined" "undetermined" "$(crumb_verdict)"
+ck "main boot + no AP_CON -> reason" "ap-con-not-discovered" "$(crumb_reason)"
+( AP_CON=""; main stash >/dev/null 2>&1 ); ck "main stash + no AP_CON -> rc1 (apply aborts)" "1" "$?"
+( AP_CON=""; main up >/dev/null 2>&1 );    ck "main up + no AP_CON -> rc1 (apply aborts)"    "1" "$?"
+
+echo "---"; echo "PASS=$pass FAIL=$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Why

Three verdict-path robustness gaps in the bridged-mode safety watchdog (#19), surfaced by the Unit 7 review and sharpened by an independent plan review.

## What

1. **Revert a half-switched state in switch mode.** An enter-Bridged apply that aborts before enslaving the AP leaves `br0` up + `eth0` enslaved but the AP not a port — a state the deadman previously *skipped* (no revert), stranding a half-built bridge. `run_verdict` now detects the **positive partial-state signature** (`br0` connected AND `eth0` is the `br0` port, gated behind `!is_ap_bridged`) and reverts — **switch mode only**, and only after **re-confirming `is_ap_bridged` is still false** (switch lacks the boot settle and `is_ap_bridged` is a single un-retried nmcli read), so a transient false-negative can never revert a healthy device. Boot keeps its plain non-bridged skip.

2. **Boot discovery timeout is observable.** When nothing is bound to the AP interface after the bounded wait, write an `undetermined / ap-con-not-discovered` breadcrumb instead of synthesizing a bogus `Halos-AP` id that would false-skip a possibly-unhealthy Bridged AP. The literal fallback was mode-agnostic, so it's split: apply-gated modes (`stash`/`up`) fail (the enter-Bridged `set -e` aborts); verdict modes surface it and do nothing destructive.

3. **Persist a stranded marker on a non-clean exit.** A new `mark-exit` `ExecStopPost` hook records to `/var/lib` (the `/run` breadcrumb is tmpfs — lost on power-cycle and never written when systemd kills the process). It keys **solely on `$SERVICE_RESULT`** (for a `Type=oneshot` timeout/signal, `$EXIT_STATUS` is non-numeric). `TimeoutStartSec` raised 300→540 to cover the true worst case **including the 150s flock wait**.

## Tests

Seeds `test/ap-bridge-watchdog.test.sh` (sourced unit tests, no NM needed) + a `./run test` target — **28 tests, 0 fail**, including the critical **false-revert regression guard** (`boot + partial topology → NO revert`). Verified on halosdev: tests pass on real device bash, `systemd-analyze verify` clean, `mark-exit` writes the marker only on a non-clean exit, boot still skips on an Isolated device.

## Notes
- The partial-switch *revert* reuses the existing `do_revert` primitive (already hardware-proven by the psk-stash work); forcing a real half-switch downs eth0, so that integration is covered by the unit tests + the proven revert rather than a live teardown.
- No version bump (cycle open: VERSION 0.2.3 vs stable v0.2.2+3; CI walks +N).
- Seeds the bash test harness that **#10** will formalize. Small overlap with **#89** (different functions in the same script); land this first.

Refs #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
