### PR TITLE
fix(ap-bridge): allow br0 forwarding past Docker FORWARD DROP

### DIFF
--- a/debian/cockpit-networkmanager-halos.ap-bridge-fwd.service
+++ b/debian/cockpit-networkmanager-halos.ap-bridge-fwd.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=HaLOS bridged-AP: allow br0 client forwarding past Docker's FORWARD DROP
+Documentation=https://github.com/halos-org/cockpit-networkmanager-halos/issues/22
+# Initial apply after Docker at boot, and rule cleanup on stop / package removal.
+# Re-application on later docker (re)starts is owned by the docker.service
+# drop-in (10-ap-bridge-fwd.conf), which fires on EVERY docker start — including
+# the socket re-activation, stop+start, and crash auto-restart paths a systemd
+# PartOf= would silently miss.
+After=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/halos/ap-bridge-watchdog.sh fwd-up
+ExecStop=/usr/libexec/halos/ap-bridge-watchdog.sh fwd-down
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -49,12 +49,19 @@ override_dh_auto_install:
 	install -D -m 0750 files/halos/ap-bridge-watchdog.sh \
 		debian/cockpit-networkmanager-halos/usr/libexec/halos/ap-bridge-watchdog.sh
 
+	# Install the docker.service drop-in that re-applies the br0 FORWARD ACCEPT
+	# on every Docker (re)start (covers the paths a systemd PartOf= misses).
+	install -D -m 0644 files/systemd/docker.service.d/10-ap-bridge-fwd.conf \
+		debian/cockpit-networkmanager-halos/usr/lib/systemd/system/docker.service.d/10-ap-bridge-fwd.conf
+
 override_dh_auto_test:
 	# Skip tests for now (will be added in Issue #10)
 	@echo "Skipping tests"
 
-# The watchdog boot unit is a named systemd unit; dh_installsystemd's autodetect
-# only picks up the default <package>.service, so enable it explicitly so the
-# maintainer scripts generate enable/start (postinst) + disable/stop (postrm).
+# The watchdog boot unit and the Docker-FORWARD unit are named systemd units;
+# dh_installsystemd's autodetect only picks up the default <package>.service, so
+# enable each explicitly so the maintainer scripts generate enable/start
+# (postinst) + disable/stop (postrm).
 override_dh_installsystemd:
 	dh_installsystemd --name=ap-bridge-watchdog
+	dh_installsystemd --name=ap-bridge-fwd

--- a/files/halos/ap-bridge-watchdog.sh
+++ b/files/halos/ap-bridge-watchdog.sh
@@ -38,6 +38,12 @@
 #   mark-exit - ExecStopPost hook: on a non-clean service exit (timeout / kill)
 #            persist a stranded marker to $STATE_DIR (the /run breadcrumb is
 #            tmpfs). No AP discovery, no lock, no NM interaction.
+#   fwd-up / fwd-down - add / remove the DOCKER-USER FORWARD ACCEPT that lets
+#            Bridged-AP clients reach the upstream DHCP server past Docker's
+#            FORWARD DROP policy. Self-contained (no AP discovery, no lock, no NM);
+#            run by ap-bridge-fwd.service (boot apply + removal cleanup) and a
+#            docker.service drop-in (re-apply on every docker start). See
+#            ensure_docker_fwd for why the rule is kept present unconditionally.
 #
 # psk handling (security): the psk only ever lives in 0600-root files — the NM
 # keyfile, the stash, and a transient passwd-file during activation. NM drops the
@@ -92,10 +98,15 @@ SWITCH_WINDOW="${SWITCH_WINDOW:-45}"
 POLL_INTERVAL="${POLL_INTERVAL:-3}"
 PING_TIMEOUT="${PING_TIMEOUT:-2}"
 FLOCK_WAIT="${FLOCK_WAIT:-150}"   # max wait for the serialization lock
+FWD_WAIT="${FWD_WAIT:-30}"        # max wait for Docker to create the DOCKER-USER chain
 
 NMCLI="${NMCLI:-nmcli}"
 IP="${IP:-ip}"
 PING="${PING:-ping}"
+IPTABLES="${IPTABLES:-iptables}"
+FWD_CHAIN="${FWD_CHAIN:-DOCKER-USER}"
+SYSTEMCTL="${SYSTEMCTL:-systemctl}"
+DOCKER_UNIT="${DOCKER_UNIT:-docker.service}"
 
 log() { logger -t ap-bridge-watchdog "$*" 2>/dev/null || true; }
 
@@ -490,6 +501,79 @@ terminal_fallback() {
     return 1
 }
 
+# --- Docker FORWARD interop (bridged-AP client DHCP) -------------------------
+# Docker sets net.bridge.bridge-nf-call-iptables=1 and the FORWARD policy to
+# DROP, and only whitelists its OWN bridges. Once the AP is Bridged, a wireless
+# client's frames bridged across $BRIDGE (client <-> upstream gateway, seen by
+# iptables as -i $BRIDGE -o $BRIDGE) match no rule and hit the DROP — clients
+# associate but never obtain a DHCP lease. The device's own $BRIDGE lease keeps
+# working (local INPUT, not FORWARD), so the health verdict stays green and the
+# breakage is invisible from the device side.
+#
+# Fix: mirror Docker's own per-bridge ACCEPT, in DOCKER-USER (the chain Docker
+# preserves across its rule regeneration). The rule is inert while Isolated
+# ($BRIDGE does not exist, so it never matches) and takes effect the instant
+# $BRIDGE appears, so it is kept present unconditionally rather than toggled by
+# mode — which also makes a live Isolated->Bridged switch work with no extra
+# step. Docker recreates DOCKER-USER empty on EVERY daemon start (boot, restart,
+# socket re-activation, crash auto-restart), so the rule is re-applied after
+# Docker by a docker.service drop-in (ExecStartPost) that fires on every start —
+# not by a systemd PartOf=, which propagates only explicit restart/stop jobs and
+# would silently miss the socket, stop+start, and crash-restart paths.
+#
+# The `iptables` calls take the xtables lock with `-w`: fwd-up runs right after
+# docker.service becomes active, when Docker is still writing its own rules and
+# holding the lock, so an unlocked call would fail-fast and leave the rule off.
+
+# Whether the Docker daemon is up. Lets fwd-up tell "Docker not installed/running"
+# (rule irrelevant -> success) from "Docker up but its chain never appeared"
+# (real failure worth surfacing) when the DOCKER-USER wait times out.
+docker_active() {
+    command -v "$SYSTEMCTL" >/dev/null 2>&1 || return 1
+    $SYSTEMCTL is-active --quiet "$DOCKER_UNIT" 2>/dev/null
+}
+
+ensure_docker_fwd() {
+    command -v "$IPTABLES" >/dev/null 2>&1 || { log "fwd: no $IPTABLES; skipping"; return 0; }
+    # DOCKER-USER exists only once Docker has built its chains. Docker creates it
+    # asynchronously, so wait (bounded).
+    local deadline; deadline=$(( $(date +%s) + FWD_WAIT ))
+    while ! $IPTABLES -n -L "$FWD_CHAIN" >/dev/null 2>&1; do
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            if docker_active; then
+                # Docker is up but its chain never appeared (slow start, an
+                # iptables-backend mismatch, or lock loss). The rule is required
+                # and NOT installed — fail so the unit surfaces it, rather than
+                # reporting success and hiding broken bridged-client DHCP.
+                log "fwd: Docker active but $FWD_CHAIN absent after ${FWD_WAIT}s; rule NOT installed"
+                return 1
+            fi
+            log "fwd: $FWD_CHAIN absent and Docker not active; nothing to do"
+            return 0
+        fi
+        sleep 1
+    done
+    if $IPTABLES -w 5 -C "$FWD_CHAIN" -i "$BRIDGE" -o "$BRIDGE" -j ACCEPT 2>/dev/null; then
+        return 0   # already present (idempotent)
+    fi
+    if $IPTABLES -w 5 -I "$FWD_CHAIN" -i "$BRIDGE" -o "$BRIDGE" -j ACCEPT 2>/dev/null; then
+        log "fwd: added $BRIDGE forward ACCEPT to $FWD_CHAIN"
+        return 0
+    fi
+    log "fwd: FAILED to add $BRIDGE forward ACCEPT to $FWD_CHAIN"
+    return 1
+}
+
+remove_docker_fwd() {
+    command -v "$IPTABLES" >/dev/null 2>&1 || return 0
+    $IPTABLES -n -L "$FWD_CHAIN" >/dev/null 2>&1 || return 0
+    # Delete every copy (idempotent; tolerate the rule already being absent).
+    while $IPTABLES -w 5 -C "$FWD_CHAIN" -i "$BRIDGE" -o "$BRIDGE" -j ACCEPT 2>/dev/null; do
+        $IPTABLES -w 5 -D "$FWD_CHAIN" -i "$BRIDGE" -o "$BRIDGE" -j ACCEPT 2>/dev/null || break
+    done
+    log "fwd: ensured $BRIDGE forward ACCEPT absent from $FWD_CHAIN"
+}
+
 # --- Orchestration -----------------------------------------------------------
 
 do_revert() {
@@ -569,6 +653,14 @@ main() {
         return
     fi
 
+    # fwd-up/fwd-down are self-contained iptables ops (no AP discovery, no NM, no
+    # lock): the rule is inert while Isolated, so it needs no bridged-state check
+    # and never races the verdict/revert critical section. Handle them here.
+    case "$mode" in
+        fwd-up)   ensure_docker_fwd; return ;;
+        fwd-down) remove_docker_fwd; return ;;
+    esac
+
     # Discover the managed AP connection by its interface (id is hostname-derived,
     # not a fixed name). An explicit AP_CON env still overrides.
     if [ -z "$AP_CON" ]; then
@@ -641,7 +733,7 @@ main() {
             stash_psk
             ;;
         *)
-            echo "usage: $0 {stash|up|boot|switch|revert|mark-exit}" >&2
+            echo "usage: $0 {stash|up|boot|switch|revert|mark-exit|fwd-up|fwd-down}" >&2
             return 2
             ;;
     esac

--- a/files/systemd/docker.service.d/10-ap-bridge-fwd.conf
+++ b/files/systemd/docker.service.d/10-ap-bridge-fwd.conf
@@ -1,0 +1,8 @@
+# Re-apply the HaLOS bridged-AP br0 FORWARD ACCEPT after every Docker start.
+# Docker recreates the DOCKER-USER chain empty on each daemon start (boot,
+# restart, socket re-activation, crash auto-restart), so the rule must be
+# re-added afterwards. This ExecStartPost fires on all of those, unlike a
+# systemd PartOf= dependency, which propagates only explicit restart/stop jobs.
+# Leading `-`: a failure here must never block the container stack.
+[Service]
+ExecStartPost=-/usr/libexec/halos/ap-bridge-watchdog.sh fwd-up

--- a/test/ap-bridge-watchdog.test.sh
+++ b/test/ap-bridge-watchdog.test.sh
@@ -107,5 +107,57 @@ ck "main boot + no AP_CON -> reason" "ap-con-not-discovered" "$(crumb_reason)"
 ( AP_CON=""; main stash >/dev/null 2>&1 ); ck "main stash + no AP_CON -> rc1 (apply aborts)" "1" "$?"
 ( AP_CON=""; main up >/dev/null 2>&1 );    ck "main up + no AP_CON -> rc1 (apply aborts)"    "1" "$?"
 
+# --- Docker-FORWARD helpers: iptables stubbed by chain-exists + rule count ---
+# The rule is inert while Isolated, so ensure/remove are pure idempotent iptables
+# ops; model DOCKER-USER as a boolean "chain exists" + an integer rule count.
+# The stub skips a leading `-w N` (the xtables lock-wait) so it dispatches on the
+# action flag regardless. STUB_FWD_INSERT_FAILS simulates a failed insert.
+STUB_FWD_CHAIN_EXISTS=1 STUB_FWD_RULES=0 STUB_FWD_INSERT_FAILS=0
+iptables() {
+    [ "$1" = "-w" ] && shift 2                    # drop `-w N`
+    case "$1" in
+        -n) [ "$STUB_FWD_CHAIN_EXISTS" = 1 ] ;;   # -n -L CHAIN : chain exists?
+        -C) [ "$STUB_FWD_RULES" -gt 0 ] ;;        # rule present?
+        -I) [ "$STUB_FWD_INSERT_FAILS" = 1 ] && return 1
+            STUB_FWD_RULES=$((STUB_FWD_RULES+1)) ;;
+        -D) STUB_FWD_RULES=$((STUB_FWD_RULES-1)) ;;
+        *)  return 0 ;;
+    esac
+}
+
+STUB_FWD_CHAIN_EXISTS=1 STUB_FWD_RULES=0
+ensure_docker_fwd; ck "fwd ensure adds when absent"   1 "$STUB_FWD_RULES"
+ensure_docker_fwd; ck "fwd ensure idempotent"         1 "$STUB_FWD_RULES"
+remove_docker_fwd; ck "fwd remove deletes rule"       0 "$STUB_FWD_RULES"
+remove_docker_fwd; ck "fwd remove idempotent"         0 "$STUB_FWD_RULES"
+
+# remove drains ALL duplicate copies, not just one
+STUB_FWD_CHAIN_EXISTS=1 STUB_FWD_RULES=3
+remove_docker_fwd; ck "fwd remove drains duplicates"  0 "$STUB_FWD_RULES"
+
+# insert failure surfaces as rc1 (so the unit fails rather than silently no-op)
+STUB_FWD_CHAIN_EXISTS=1 STUB_FWD_RULES=0 STUB_FWD_INSERT_FAILS=1
+ensure_docker_fwd; ck "fwd ensure rc1 when insert fails" 1 "$?"
+STUB_FWD_INSERT_FAILS=0
+
+# Docker not up (chain absent, docker inactive): add nothing, still succeed
+STUB_FWD_CHAIN_EXISTS=0 STUB_FWD_RULES=0 FWD_WAIT=0 SYSTEMCTL=false
+ensure_docker_fwd; rc=$?
+ck "fwd ensure rc0 when chain absent + docker inactive" 0 "$rc"
+ck "fwd ensure no-op when chain absent"                 0 "$STUB_FWD_RULES"
+
+# Docker ACTIVE but chain never appears: surface failure (rc1), don't hide it
+STUB_FWD_CHAIN_EXISTS=0 STUB_FWD_RULES=0 FWD_WAIT=0 SYSTEMCTL=true
+ensure_docker_fwd; ck "fwd ensure rc1 when docker active but chain absent" 1 "$?"
+SYSTEMCTL=false
+
+# iptables not installed at all: no-op success
+( IPTABLES="definitely-not-a-real-cmd"; ensure_docker_fwd ); ck "fwd ensure rc0 when iptables missing" 0 "$?"
+
+# main() dispatches fwd-up/fwd-down self-contained (before AP discovery + lock)
+STUB_FWD_CHAIN_EXISTS=1 STUB_FWD_RULES=0
+main fwd-up;   ck "main fwd-up adds rule"      1 "$STUB_FWD_RULES"
+main fwd-down; ck "main fwd-down removes rule" 0 "$STUB_FWD_RULES"
+
 echo "---"; echo "PASS=$pass FAIL=$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## Problem

On any device running Docker (i.e. all HaLOS devices), a **Bridged**-mode AP lets clients associate but they **never get a DHCP lease** — and it recurs on every reboot. Root-caused on halpi.hurma (issue #22).

Docker sets `net.bridge.bridge-nf-call-iptables=1` and the `FORWARD` policy to `DROP`, and only whitelists its own bridges. So a wireless client's frames bridged across `br0` (client ↔ upstream gateway, seen by iptables as `-i br0 -o br0`) match no rule and hit the DROP. The device's own `br0` lease keeps working (local `INPUT`, not `FORWARD`), so the health verdict stays green and the breakage is invisible from the device side.

## Fix

Mirror Docker's own per-bridge ACCEPT — one rule in `DOCKER-USER`:

```
iptables -I DOCKER-USER -i br0 -o br0 -j ACCEPT
```

- New `ap-bridge-fwd.service` (`After=`/`PartOf=docker.service`) applies it at boot after Docker (which recreates `DOCKER-USER` empty on daemon start) and refreshes it on `systemctl restart docker`.
- New watchdog modes `fwd-up` / `fwd-down` (self-contained: no AP discovery, no NM, no lock) do the idempotent add/remove; `ExecStop` removes the rule on unit stop / package removal.

The rule is **inert while Isolated** (`br0` doesn't exist, so it never matches) and takes effect the instant `br0` appears — so it needs no bridged-state gating and covers a live Isolated→Bridged switch for free.

## Testing

- Extended `test/ap-bridge-watchdog.test.sh` (iptables stubbed) — ensure/remove idempotency, chain-absent (Docker down) no-op, missing-iptables no-op. `./run test`: 35 pass, shellcheck clean.
- Verified end-to-end on halpi.hurma via the equivalent interim rule + unit: a restarted SensESP client associated and leased through the bridge.

Closes #22.

---

Note for deployers: halpi.hurma currently carries an ad-hoc `halos-ap-bridge-fwd.service` (the interim manual fix). Remove it once this package version is deployed — the two are idempotent, but the packaged unit supersedes it.
